### PR TITLE
Implement streaming server with chat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,28 +1,32 @@
 # Plataforma de Streaming de Filmes com Amigos
 
 ## Descrição
-Este projeto consiste em uma plataforma web que permite que você transmita filmes para seus amigos em tempo real, utilizando RTMP e HLS, com um chat integrado e controle de acesso via código de convite.
+Este projeto permite transmitir filmes em tempo real para seus amigos utilizando RTMP e HLS. Possui chat integrado e controle de acesso via código de convite.
 
 ## Tecnologias Utilizadas
 - **Node.js** para o servidor backend.
-- **Nginx** para servir como proxy reverso e gerenciar o RTMP.
+- **Nginx** com módulo **RTMP** para receber o stream e gerar HLS.
 - **HLS** para entrega do vídeo com baixa latência.
 - **WebSockets** para o chat em tempo real.
 - **HTML/CSS/JavaScript** para a interface do usuário.
 
 ## Funcionalidades Principais
-1. **Transmissão de Vídeo:** Configurar o Nginx para receber o stream RTMP e convertê-lo em HLS.
-2. **Autenticação:** Página de login que solicita um código de convite e, se correto, pede nome e e-mail.
-3. **Player de Vídeo:** Página principal com o player de vídeo usando HLS.
-4. **Chat:** Integração de um chat em tempo real para comunicação entre os usuários.
+1. **Transmissão de Vídeo**: O Nginx recebe o stream RTMP e disponibiliza em HLS.
+2. **Autenticação**: Página de login solicita o código de convite, nome e e‑mail.
+3. **Player de Vídeo**: Página principal com player HLS.
+4. **Chat**: Mensagens em tempo real entre os participantes.
 
 ## Estrutura de Arquivos
-- **server.js**: Servidor principal em Node.js.
-- **public/**: Pasta com os arquivos estáticos (HTML, CSS, JS).
-- **chat/**: Módulo para gerenciar o chat em tempo real.
-- **nginx.conf**: Configuração do Nginx para RTMP e HLS.
+- `server.js`: Servidor principal em Node.js.
+- `public/`: Arquivos estáticos (HTML, CSS e JS).
+- `chat/`: Módulo para o chat em tempo real.
+- `nginx.conf`: Exemplo de configuração do Nginx/RTMP.
 
-## Passos Iniciais
-1. Configurar o ambiente Node.js e instalar as dependências (Express, WebSocket, etc.).
-2. Configurar o Nginx para receber o stream RTMP e converter em HLS.
-3. Criar as rotas no servidor
+## Como Usar
+1. Instale as dependências com `npm install`.
+2. Defina a variável `INVITE_CODE` (opcional) e execute `node server.js`.
+3. Inicie o Nginx usando o `nginx.conf` presente no projeto.
+4. Transmita para `rtmp://<servidor>:1935/live/stream` através do OBS.
+5. Acesse `http://<servidor>:3000/login.html` e informe o código de convite.
+
+Este repositório serve como ponto de partida para estudos de streaming e chat em tempo real.

--- a/chat/index.js
+++ b/chat/index.js
@@ -1,0 +1,17 @@
+const WebSocket = require('ws');
+
+function initChat(server) {
+  const wss = new WebSocket.Server({ server });
+  wss.on('connection', (ws, req) => {
+    const params = new URLSearchParams(req.url.replace('/?', ''));
+    const username = params.get('username') || 'Anon';
+    ws.on('message', (msg) => {
+      wss.clients.forEach((client) => {
+        if (client.readyState === WebSocket.OPEN) {
+          client.send(`${username}: ${msg}`);
+        }
+      });
+    });
+  });
+}
+module.exports = initChat;

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,30 @@
+worker_processes auto;
+
+rtmp {
+    server {
+        listen 1935;
+        chunk_size 4096;
+
+        application live {
+            live on;
+            record off;
+            hls on;
+            hls_path /tmp/hls;
+            hls_fragment 1s;
+        }
+    }
+}
+
+http {
+    server {
+        listen 8000;
+        location /hls {
+            types {
+                application/vnd.apple.mpegurl m3u8;
+                video/mp2t ts;
+            }
+            root /tmp;
+            add_header Cache-Control no-cache;
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "pdvpmb",
+  "version": "1.0.0",
+  "description": "Este projeto consiste em uma plataforma web que permite que você transmita filmes para seus amigos em tempo real, utilizando RTMP e HLS, com um chat integrado e controle de acesso via código de convite.",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "express": "^5.1.0",
+    "express-session": "^1.18.1",
+    "ws": "^8.18.3"
+  }
+}

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Streaming de Filmes</title>
+  <style>
+    body { display: flex; font-family: sans-serif; }
+    #video { flex: 3; }
+    #chat { flex: 1; margin-left: 20px; }
+    #messages { height: 300px; overflow-y: scroll; border: 1px solid #ccc; padding: 5px; }
+  </style>
+</head>
+<body>
+  <div id="video">
+    <video id="player" controls autoplay></video>
+  </div>
+  <div id="chat">
+    <div id="messages"></div>
+    <form id="form">
+      <input type="text" id="msg" autocomplete="off" placeholder="Mensagem" />
+      <button>Enviar</button>
+    </form>
+  </div>
+<script src="https://cdn.jsdelivr.net/npm/hls.js@latest"></script>
+<script>
+  const video = document.getElementById('player');
+  const source = '/hls/stream.m3u8';
+  if (Hls.isSupported()) {
+    const hls = new Hls();
+    hls.loadSource(source);
+    hls.attachMedia(video);
+  } else if (video.canPlayType('application/vnd.apple.mpegurl')) {
+    video.src = source;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const username = params.get('u') || 'Anon';
+
+  const ws = new WebSocket(`ws://${window.location.host}/?username=${username}`);
+  const form = document.getElementById('form');
+  const msgInput = document.getElementById('msg');
+  const messages = document.getElementById('messages');
+  ws.onmessage = (event) => {
+    const div = document.createElement('div');
+    div.textContent = event.data;
+    messages.appendChild(div);
+    messages.scrollTop = messages.scrollHeight;
+  };
+  form.addEventListener('submit', (e) => {
+    e.preventDefault();
+    ws.send(msgInput.value);
+    msgInput.value = '';
+  });
+</script>
+</body>
+</html>

--- a/public/login.html
+++ b/public/login.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8">
+  <title>Login</title>
+</head>
+<body>
+  <form method="POST" action="/login">
+    <div>
+      <label>Código de convite:</label>
+      <input name="code" required />
+    </div>
+    <div>
+      <label>Nome de usuário:</label>
+      <input name="username" required />
+    </div>
+    <div>
+      <label>Email:</label>
+      <input name="email" required />
+    </div>
+    <button>Entrar</button>
+    <p style="color:red;">
+      <script>
+        if (new URLSearchParams(window.location.search).has('error')) {
+          document.write('Código inválido');
+        }
+      </script>
+    </p>
+  </form>
+</body>
+</html>

--- a/server.js
+++ b/server.js
@@ -1,0 +1,41 @@
+const express = require('express');
+const path = require('path');
+const http = require('http');
+const session = require('express-session');
+const initChat = require('./chat');
+
+const INVITE_CODE = process.env.INVITE_CODE || 'SECRET';
+const PORT = process.env.PORT || 3000;
+
+const app = express();
+const server = http.createServer(app);
+initChat(server);
+
+app.use(express.static(path.join(__dirname, 'public')));
+app.use(express.urlencoded({ extended: true }));
+app.use(session({ secret: 'stream-secret', resave: false, saveUninitialized: true }));
+
+function requireInvite(req, res, next) {
+  if (req.session.allowed) return next();
+  res.redirect('/login.html');
+}
+
+app.post('/login', (req, res) => {
+  const { code, username, email } = req.body;
+  if (code === INVITE_CODE) {
+    req.session.allowed = true;
+    req.session.username = username || 'Anon';
+    req.session.email = email || '';
+    res.redirect(`/?u=${encodeURIComponent(username)}`);
+  } else {
+    res.redirect('/login.html?error=1');
+  }
+});
+
+app.get('/', requireInvite, (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+server.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- set up Express server with session and invite code
- add chat module using WebSockets
- create login page and streaming page
- supply example nginx RTMP/HLS config
- add README instructions
- ignore node_modules

## Testing
- `npm install`
- `node server.js` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_6875b611ce80832988888c253ddacbe9