### PR TITLE
Add docker-compose for nginx streaming server

### DIFF
--- a/docker/nginx/docker-compose.yml
+++ b/docker/nginx/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3.8'
+services:
+  nginx:
+    image: alfg/nginx-rtmp:latest
+    container_name: nginx-stream
+    restart: unless-stopped
+    ports:
+      - "1935:1935" # RTMP
+      - "8000:8000" # HLS over HTTP
+    volumes:
+      - ../../nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./hls:/tmp/hls


### PR DESCRIPTION
## Summary
- provide docker-compose configuration for running nginx with RTMP/HLS
- keep an empty `hls` directory for generated segments

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875b969a66883298ee6d3b9e4ce28ea